### PR TITLE
Update setup_dependencies.sh

### DIFF
--- a/preproc/setup_dependencies.sh
+++ b/preproc/setup_dependencies.sh
@@ -4,7 +4,7 @@ pip install -r requirements_extra.txt
 # install droid-slam
 echo "Installing DROID-SLAM..."
 cd DROID-SLAM
-pip install .
+python setup.py install
 cd ..
 
 # install unidepth


### PR DESCRIPTION
Resolves:
```  Preparing metadata (setup.py) ... done
ERROR: More than one .egg-info directory found in /tmp/pip-pip-egg-info-nlrx2ewq
```

DROID-SLAM creates two .egg files: one for `droid_backends` and one for `lietorch`, which creates an issue when using `pip install .`

Use `python setup.py install` instead, as documented here:
https://github.com/princeton-vl/DROID-SLAM?tab=readme-ov-file